### PR TITLE
Jupyterlab 2.0.2 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,19 +32,19 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@jupyterlab/application": "^1.0.2",
-    "@jupyterlab/apputils": "^1.0.2",
-    "@jupyterlab/cells": "^1.0.2",
-    "@jupyterlab/docregistry": "^1.0.2",
-    "@jupyterlab/notebook": "^1.0.2",
-    "@phosphor/coreutils": "^1.3.1",
-    "@phosphor/disposable": "^1.2.0",
-    "@phosphor/messaging": "^1.2.3",
-    "@phosphor/widgets": "^1.8.1"
+    "@jupyterlab/application": "^2.0.2",
+    "@jupyterlab/apputils": "^2.0.2",
+    "@jupyterlab/cells": "^2.0.2",
+    "@jupyterlab/docregistry": "^2.0.2",
+    "@jupyterlab/notebook": "^2.0.2",
+    "@lumino/coreutils": "^1.4.2",
+    "@lumino/disposable": "^1.3.5",
+    "@lumino/messaging": "^1.3.3",
+    "@lumino/widgets": "^1.11.1"
   },
   "devDependencies": {
-    "rimraf": "^2.6.1",
-    "typescript": "~3.5.2"
+    "rimraf": "~3.0.0",
+    "typescript": "~3.7.3"
   },
   "sideEffects": [
     "style/*.css"

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import {
   Cell
 } from '@jupyterlab/cells';
 
-import { ISettingRegistry } from '@jupyterlab/coreutils';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
 
 const plugin: JupyterFrontEndPlugin<void> = {
   activate,


### PR DESCRIPTION
Fixes #19 
 
I bumped the versions/names for the dependencies and devdependencies and updated the ISettingRegistry import.   I get an error when building saying the requested popper.js version is outdated but it still seems to work. 

One problem is that the caret on the headers is missing. The mouse changes when you hover over it, but you just can't see it. I don't know enough Typescript to know what the fix would be.